### PR TITLE
Ask OS to don't frag packet. Set the DF bit in outgoing packet.

### DIFF
--- a/src/raw.cc
+++ b/src/raw.cc
@@ -230,6 +230,9 @@ void ExportConstants (Handle<Object> target) {
 	Nan::Set(socket_option, Nan::New("IP_OPTIONS").ToLocalChecked(), Nan::New<Number>(IP_OPTIONS));
 	Nan::Set(socket_option, Nan::New("IP_TOS").ToLocalChecked(), Nan::New<Number>(IP_TOS));
 	Nan::Set(socket_option, Nan::New("IP_TTL").ToLocalChecked(), Nan::New<Number>(IP_TTL));
+	Nan::Set(socket_option, Nan::New("IP_MTU_DISCOVER").ToLocalChecked(), Nan::New<Number>(IP_MTU_DISCOVER));
+	Nan::Set(socket_option, Nan::New("IP_PMTUDISC_DO").ToLocalChecked(), Nan::New<Number>(IP_PMTUDISC_DO));
+	Nan::Set(socket_option, Nan::New("IP_PMTUDISC_DONT").ToLocalChecked(), Nan::New<Number>(IP_PMTUDISC_DONT));
 
 #ifdef _WIN32
 	Nan::Set(socket_option, Nan::New("IPV6_HDRINCL").ToLocalChecked(), Nan::New<Number>(IPV6_HDRINCL));


### PR DESCRIPTION
I use node-raw-socket with node-net-ping (https://github.com/stephenwvickers/node-net-ping) in order to check the MTU of CPE routers. I do PMTUD in my own.
But for this, I need to set one option on socket like:
var dontFrag = raw.SocketOption.IP_PMTUDISC_DO;
socket.setOption(raw.SocketLevel.IPPROTO_IP, raw.SocketOption.IP_MTU_DISCOVER, dontFrag);

Please, can you merge my patch please ?

If you do, I will ask node-net-ping to patch code in order to call setOption() from raw-socket.

Have a nice day.