### PR TITLE
Added bindToAddress and bindToDevice

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ privileged users.  If this is the case an exception will be thrown on socket
 creation using a message similar to `Operation not permitted` (this message
 is likely to be different depending on operating system version).
 
+For linux platforms, raw sockets can be created by a program that have the
+`cap_net_raw` capability. It can be given to node with the following
+command: `setcap cap_net_raw=pe /path/to/node`.
+
 For MAC OS X platforms, when raw socket creation fails, this module will
 re-attempt to create a socket using the `SOCK_DGRAM` socket type for when the
 protocol specified is `IPPROTO_ICMP` before throwing an exception.  This
@@ -325,6 +329,9 @@ items:
  * `checksumOffset` - When `generateChecksums` is `true` specifies how many
    bytes to index into the send buffer to write automatically generated
    checksums, defaults to `0`
+ * `bindToAddress` - An ip address to bind the socket to.
+ * `bindToDevice` - (linux only) A device name to bind the socket to.
+
 
 An exception will be thrown if the underlying raw socket could not be created.
 The error will be an instance of the `Error` class.
@@ -521,6 +528,17 @@ The previous example can be re-written to use this form:
 
     socket.setOption (level, option, 1);
 
+## socket.bindToAddress (address)
+
+The `bindToAddress()` method binds the socket to the specified ip address,
+using the operating system `bind()` function.
+
+## socket.bindToDevice (device)
+
+The `bindToDevice()` method is only availble on linux platforms, and
+binds the socket to the specified device, using the operating system
+`setsockopt (socket, SOL_SOCKET, SO_BINDTODEVICE, device, device.length);`
+
 # Example Programs
 
 Example programs are included under the modules `example` directory.
@@ -676,6 +694,10 @@ Bug reports should be sent to <stephen.vickers.sv@gmail.com>.
 ## Version 1.5.1 - 16/11/2016
 
  * Explicitly publish to npm using UNIX line endings
+
+## Version FORKED/some 1.5.2 - 14/10/2017
+
+ * Added bindToAddress and bindToDevice
 
 # Roadmap
 

--- a/index.js
+++ b/index.js
@@ -53,6 +53,13 @@ function Socket (options) {
 					: AddressFamily.IPv4)
 		);
 
+	if (options) {
+		options.bindToAddress && this.bindToAddress(options.bindToAddress);
+		if (raw.SocketOption.SO_BINDTODEVICE) {
+			options.bindToDevice && this.bindToDevice(options.bindToDevice);
+		}
+	}
+
 	var me = this;
 	this.wrap.on ("sendReady", this.onSendReady.bind (me));
 	this.wrap.on ("recvReady", this.onRecvReady.bind (me));
@@ -69,6 +76,16 @@ Socket.prototype.close = function () {
 
 Socket.prototype.getOption = function (level, option, value, length) {
 	return this.wrap.getOption (level, option, value, length);
+}
+
+Socket.prototype.bindToAddress = function (address) {
+	return this.wrap.bindToAddress (address);
+}
+
+if (raw.SocketOption.SO_BINDTODEVICE) {
+	Socket.prototype.bindToDevice = function (device) {
+		return this.wrap.bindToDevice (device);
+	}
 }
 
 Socket.prototype.onClose = function () {

--- a/src/raw.h
+++ b/src/raw.h
@@ -76,6 +76,11 @@ private:
 
 	static NAN_METHOD(GetOption);
 
+	static NAN_METHOD(BindToAddress);
+#ifdef __linux__
+	static NAN_METHOD(BindToDevice);
+#endif
+
 	static NAN_METHOD(New);
 
 	static void OnClose (uv_handle_t *handle);


### PR DESCRIPTION
Added bindToAddress and bindToDevice to the raw socket.

* socket.bindToAddress (address)

The `bindToAddress()` method binds the socket to the specified ip address,
using the operating system `bind()` function.

* socket.bindToDevice (device)

The `bindToDevice()` method is only availble on linux platforms, and
binds the socket to the specified device, using the operating system
`setsockopt (socket, SOL_SOCKET, SO_BINDTODEVICE, device, device.length);`